### PR TITLE
fixing a webpack warning and updating style to more closely match eslint stylish formatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,13 @@ var extend = function (obj) {
   return obj;
 };
 
-var rcFinder = new RcFinder('coffeelint.json', {
+var rcFinder1 = new RcFinder('.coffeelint.json', {
+  loader: function (rcpath) {
+    return rcpath;
+  }
+});
+
+var rcFinder2 = new RcFinder('coffeelint.json', {
   loader: function (rcpath) {
     return rcpath;
   }
@@ -29,7 +35,11 @@ var rcFinder = new RcFinder('coffeelint.json', {
 
 var loadConfigSync = function () {
   var folder = path.dirname(this.resourcePath);
-  var rcpath = rcFinder.find(folder);
+  var rcFinders = [rcFinder1, rcFinder2];
+  var rcpath;
+  while (rcFinders.length && typeof rcpath !== 'string') {
+    rcpath = rcFinders.shift().find(folder);
+  }
   if (typeof rcpath !== 'string') {
     // No .coffeelint.json found.
     return {};
@@ -42,9 +52,13 @@ var loadConfigSync = function () {
 
 var loadConfigAsync = function (callback) {
   var folder = path.dirname(this.resourcePath);
-  rcFinder.find(folder, function (err, rcpath) {
+  var rcFinders = [rcFinder1, rcFinder2];
+  var rcFinderCallback = function (err, rcpath) {
     if (typeof rcpath !== 'string') {
       // No .coffeelint.json found.
+      if (rcFinders.length) {
+        return rcFinders.shift().find(folder, rcFinderCallback);
+      }
       return callback(null, {});
     }
 
@@ -62,7 +76,8 @@ var loadConfigAsync = function (callback) {
       }
       callback(err, options);
     });
-  }.bind(this));
+  }.bind(this);
+  rcFinders.shift().find(folder, rcFinderCallback);
 };
 
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var extend = function (obj) {
   return obj;
 };
 
-var rcFinder = new RcFinder('.coffeelint.json', {
+var rcFinder = new RcFinder('coffeelint.json', {
   loader: function (rcpath) {
     return rcpath;
   }
@@ -76,8 +76,6 @@ var checkSource = function (source, config) {
   extend(config, query);
 
   // Move flags.
-  var emitErrors = config.emitErrors;
-  delete config.emitErrors;
   var failOnHint = config.failOnHint;
   delete config.failOnHint;
 
@@ -87,7 +85,7 @@ var checkSource = function (source, config) {
 
   var errors = linter(source, config);
   if (errors.length > 0) {
-    reporter.call(this, errors, emitErrors);
+    reporter.call(this, errors);
 
     if (failOnHint && errors.length > 0) {
       throw new Error('Module failed because of coffeelint error.');

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -2,41 +2,48 @@
 var chalk = require( 'chalk' );
 var table = require( 'text-table' );
 
-module.exports = function(errors, emitErrors) {
-  var emitter = emitErrors ? this.emitError : this.emitWarning;
+module.exports = function(errors) {
   var errorCount = errors.filter(function(error) { return (error.level === 'error'); }).length;
-  var warningCount = errors.filter(function(error) { return (error.level === 'warning'); }).length;
+  var warningCount = errors.filter(function(error) { return (error.level === 'warn'); }).length;
+  var emitter = errorCount ? this.emitError : this.emitWarning;
 
   var report = table(errors.map(function(error) {
     var line = [
       '',
-      chalk.gray(error.lineNumber),
-      chalk.yellow(error.level),
-      error.message
+      chalk.reset.grey(error.lineNumber),
+      error.level === 'error' ? chalk.red('error') : chalk.yellow('warning'),
+      error.message,
+      chalk.dim(error.name || "")
     ];
 
     if (error.context) {
-      line.push(chalk.grey(error.context));
+       line.push(chalk.grey('\'' + error.context + '\''));
     }
 
     return line;
   }));
 
   if (errors.length > 0) {
-    report = report +
+    report = '\n' +
+      chalk.underline[errorCount ? "red" : "yellow"](this.resourcePath) +
+      '\n' +
+      report +
       '\n\n' +
-      chalk.yellow([
+      chalk.bold[errorCount ? "red" : "yellow"]([
         '✖ ',
         errors.length,
         ' problems',
         ' (',
         errorCount,
-        ' errors, ',
+        ' error' +
+        (errorCount !== 1 ? 's' : '') +
+        ', ',
         warningCount,
-        ' warnings)'
+        ' warning' +
+        (warningCount !== 1 ? 's' : '') +
+        ')\n'
       ].join(''));
   }
 
-  emitter(report);
-
+  emitter(new Error(report));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-terrible-coffeelint-loader",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "author": "Tommy Brunn <tommy.brunn@gmail.com",
   "description": "Coffeelint loader module for webpack",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-terrible-coffeelint-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Tommy Brunn <tommy.brunn@gmail.com",
   "description": "Coffeelint loader module for webpack",
   "dependencies": {


### PR DESCRIPTION
- Fixed webpack warning `(Emitted value instead of an instance of Error)`
- All of our other tools expect `coffeelint.json` instead of `.coffeelint.json`
- Updated reporter style to more closely match ESLint's Stylish formatter