### PR TITLE
Webpack 4 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ var loadConfigAsync = function (callback) {
 
 var checkSource = function (source, config) {
   // Copy options to own object.
-  var options = this.options.coffeelint;
+  var options = (this.options && this.options.coffeelint) || {};
   extend(config, options);
 
   // Copy query to own object.


### PR DESCRIPTION
Webpack 4 no longer passes in an options object